### PR TITLE
ARXIVNG-1602 redirect to running/existing task

### DIFF
--- a/fulltext/controllers.py
+++ b/fulltext/controllers.py
@@ -85,6 +85,8 @@ def extract(paper_id: str, id_type: str = 'arxiv') -> Response:
         status_endpoint = 'fulltext.task_status'
     elif id_type == 'submission':
         status_endpoint = 'fulltext.submission_task_status'
+    else:
+        raise NotFound('No such identifier')
 
     # If an extraction task already exists for this paper, redirect. Don't
     # create the same task twice.

--- a/fulltext/extract.py
+++ b/fulltext/extract.py
@@ -110,6 +110,30 @@ def get_extraction_task(paper_id: str, id_type: str,
     return ExtractionTask(task_id=task_id(paper_id, id_type, version), **data)
 
 
+def extraction_task_exists(paper_id: str, id_type: str,
+                           version: Optional[str] = None) -> bool:
+    """
+    Check whether an extraction task exists.
+
+    Parameters
+    ----------
+    paper_id : str
+        Unique identifier for the paper being extracted. Usually an arXiv ID.
+    id_type : str
+        Either 'arxiv' or 'submission'.
+    version : str
+        Extractor version (optional). Will use the current version if not
+        provided.
+
+    Returns
+    -------
+    bool
+
+    """
+    result = extract_fulltext.AsyncResult(task_id(paper_id, id_type, version))
+    return result.status != 'PENDING'   # 'PENDING' => non-existant.
+
+
 @celery_app.task
 def extract_fulltext(document_id: str, pdf_url: str, id_type: str = 'arxiv') \
         -> Dict[str, str]:

--- a/fulltext/tests/test_controllers.py
+++ b/fulltext/tests/test_controllers.py
@@ -57,12 +57,13 @@ class TestRetrieve(TestCase):
 class TestExtract(TestCase):
     """Test requesting a new extraction."""
 
-    @mock.patch(f'{controllers.__name__}.create_extraction_task')
+    @mock.patch(f'{controllers.__name__}.extraction_task_exists')
     @mock.patch(f'{controllers.__name__}.url_for')
     @mock.patch(f'{controllers.__name__}.pdf.exists')
     def test_arxiv_paper_exists(self, mock_exists, mock_url_for,
                                 mock_create_extraction_task):
         """Request extraction for an existant arXiv paper."""
+        extraction_task_exists.return_value = True
         paper_id = '1234.56789v2'
         task_id = extract.task_id(paper_id, 'arxiv'),
         mock_exists.return_value = True
@@ -76,10 +77,13 @@ class TestExtract(TestCase):
         self.assertEqual(code, status.HTTP_202_ACCEPTED)
         self.assertIn('Location', headers)
 
+    @mock.patch(f'{controllers.__name__}.extraction_task_exists')
     @mock.patch(f'{controllers.__name__}.url_for')
     @mock.patch(f'{controllers.__name__}.pdf.exists')
-    def test_arxiv_paper_does_not_exist(self, mock_exists, mock_url_for):
+    def test_arxiv_paper_does_not_exist(self, mock_exists, mock_url_for,
+                                        mock_extraction_task_exists):
         """Request extraction for a non-existant arXiv paper."""
+        mock_extraction_task_exists.return_value = False
         paper_id = '1234.56789v2'
         mock_exists.return_value = False
         mock_url_for.side_effect = \
@@ -88,10 +92,13 @@ class TestExtract(TestCase):
         with self.assertRaises(NotFound):
             controllers.extract(paper_id)
 
+    @mock.patch(f'{controllers.__name__}.extraction_task_exists')
     @mock.patch(f'{controllers.__name__}.url_for')
     @mock.patch(f'{controllers.__name__}.pdf.exists')
-    def test_arxiv_submission_does_not_exist(self, mock_exists, mock_url_for):
+    def test_arxiv_submission_does_not_exist(self, mock_exists, mock_url_for,
+                                             mock_extraction_task_exists):
         """Request extraction for a non-existant submission."""
+        mock_extraction_task_exists.return_value = False
         paper_id = '1234.56789v2'
         mock_exists.return_value = False
         mock_url_for.side_effect = \


### PR DESCRIPTION
This tweaks the endpoint for requesting extraction to redirect to a running/existent task if one exists. Also tweaks the endpoint for retrieving content to redirect to a running task if it exists.